### PR TITLE
remove leftover arg

### DIFF
--- a/lib/argus/drone.rb
+++ b/lib/argus/drone.rb
@@ -23,7 +23,7 @@ module Argus
       @at
     end
 
-    def start(enable_nav_monitor=true)
+    def start
       @nav.start
       @at.start
     end


### PR DESCRIPTION
We left this arg in accidentally when we moved the `NullNavMonitor` into the initializer
