### PR TITLE
Remove double quotes

### DIFF
--- a/spec/argus/at_commander_spec.rb
+++ b/spec/argus/at_commander_spec.rb
@@ -7,8 +7,8 @@ describe Argus::ATCommander do
   describe "#tick" do
     Given(:expected_commands) {
       [
-        "AT\\*REF=\\d+,0",
-        "AT\\*PCMD=\\d+,0,0,0,0,0",
+        'AT\*REF=\d+,0',
+        'AT\*PCMD=\d+,0,0,0,0,0',
       ]
     }
     Given(:command_pattern) { Regexp.new('\A' + expected_commands.map { |s| "#{s}\r" }.join + '\Z') }


### PR DESCRIPTION
We made the conversion to single quotes for several of the regexes so that special characters wouldn't have to be double escaped for `Rexexp.new`; the original `expected_commands` array was missed.
